### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,6 @@ Feedstock Maintainers
 =====================
 
 * [@DragaDoncila](https://github.com/DragaDoncila/)
-* [@goanpeca](https://github.com/goanpeca/)
 * [@jaimergp](https://github.com/jaimergp/)
 * [@kephale](https://github.com/kephale/)
 * [@kevinyamauchi](https://github.com/kevinyamauchi/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,6 @@ about:
 extra:
   recipe-maintainers:
     - DragaDoncila
-    - goanpeca
     - jaimergp
     - kephale
     - kevinyamauchi


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #4